### PR TITLE
Casting value type, strlen enhancement

### DIFF
--- a/src/Rules/NumberCompare.php
+++ b/src/Rules/NumberCompare.php
@@ -67,8 +67,8 @@ class NumberCompare extends AbstractNumber implements RuleSanitizeInterface, Rul
             return true;
         }
 
-        settype($received, 'float');
-        settype($compare, 'float');
+        $received = (float) $received;
+        $compare = (float) $compare;
 
         if ($this->switchOperator($operator, $received, $compare)) {
             return false;

--- a/src/Rules/NumberInterval.php
+++ b/src/Rules/NumberInterval.php
@@ -72,9 +72,9 @@ class NumberInterval extends AbstractNumber implements RuleSanitizeInterface, Ru
             return true;
         }
 
-        settype($received, 'float');
-        settype($min, 'float');
-        settype($max, 'float');
+        $received = (float) $received;
+        $min = (float) $min;
+        $max = (float) $max;
 
         if ($this->switchOperator($operator, $received, $min, $max)) {
             return false;

--- a/src/Rules/Required.php
+++ b/src/Rules/Required.php
@@ -61,7 +61,7 @@ class Required implements RuleValidateInterface
             return true;
         }
 
-        if (!strlen((string) $received)) {
+        if (strlen((string) $received) === 0) {
             $this->message = "Received value is a void string";
             return true;
         }

--- a/src/RulesHelper/AbstractNumber.php
+++ b/src/RulesHelper/AbstractNumber.php
@@ -23,10 +23,10 @@ class AbstractNumber
      */
     public function sanitize(&$value): void
     {
-        settype($value, 'float');
+        $value = (float) $value;
 
         if (fmod((float) $value, 1.0) === 0.0) {
-            settype($value, 'integer');
+            $value = (integer) $value;
         }
     }
 }

--- a/src/RulesHelper/AbstractString.php
+++ b/src/RulesHelper/AbstractString.php
@@ -23,6 +23,6 @@ class AbstractString
      */
     public function sanitize(&$value): void
     {
-        settype($value, 'string');
+        $value = (string) $value;
     }
 }


### PR DESCRIPTION
# Changed log
- The `settype` and `casting value type` are existed on this source code. Using the casting the value type directly because I think the casting value type approach should be organized.
- The `strlen` function should return type is `int`, not `bool`. And this should use the `=== 0` to check whether the result value is the void string.