### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,7 @@ language: php
 php:
 - 7.1
 - 7.2
-
-jobs:
-  include:
-    - php: 7.3.0RC1
-      dist: xenial
-      sudo: required
-      addons:
-        apt:
-          packages:
-            - libzip4
+- 7.3
 
 before_script:
 - composer install

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -174,7 +174,7 @@ class FilterTest extends TestCase
         $this->assertEquals($result, $filter->getData());
         $this->assertEquals($messages, $filter->getMessages());
 
-        $this->assertInternalType('integer', $filter->getData()['age']);
+        $this->assertIsInt($filter->getData()['age']);
     }
 
     /**
@@ -194,7 +194,7 @@ class FilterTest extends TestCase
         $this->assertEquals($result, $r->data());
         $this->assertEquals($messages, $r->messages());
 
-        $this->assertInternalType('integer', $r->data()['age']);
+        $this->assertIsInt($r->data()['age']);
     }
 
     /**

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -29,8 +29,8 @@ class ParserTest extends TestCase
     public function ruleProvider(): array
     {
         return [
-            [array( 0 => array( 0 => 'rule', 1 => 'number', 2 => array(), ), ), 'rule: number'],
-            [array( 0 => array( 0 => 'rule', 1 => 'number', 2 => array(), ), 1 => array( 0 => 'rule', 1 => 'numbercompare', 2 => array( 0 => '<', 1 => 25, ), ), ), 'rule: number numbercompare < 25'],
+            [[ 0 => [ 0 => 'rule', 1 => 'number', 2 => [], ], ], 'rule: number'],
+            [[ 0 => [ 0 => 'rule', 1 => 'number', 2 => [], ], 1 => [ 0 => 'rule', 1 => 'numbercompare', 2 => [ 0 => '<', 1 => 25, ], ], ], 'rule: number numbercompare < 25'],
             //[[0 => [0 => 'rule', 1 => 'number', 2 => [], ], 1 => [ 0 => 'rule', 1 => 'min', 2 => [15], ], 2 => [ 0 => 'rule', 1 => 'max', 2 => [30], ], ], 'rule: number min 15 max 30'],
             //[[0 => [0 => 'rule', 1 => 'number', 2 => [], ], 1 => [ 0 => 'rule', 1 => 'between', 2 => [15, 30, ], ], ],'rule: number between 15 30']
         ];

--- a/tests/Rules/CustomRuleTest.php
+++ b/tests/Rules/CustomRuleTest.php
@@ -55,10 +55,7 @@ class CustomRuleTest extends TestCase
         (new CustomRule(
             $argument,
             function (string $received): bool {
-                if ($received === 'test') {
-                    return true;
-                }
-                return false;
+                return $received === 'test';
             }
         ));
     }
@@ -74,10 +71,7 @@ class CustomRuleTest extends TestCase
         (new CustomRule(
             [],
             function (string $received): bool {
-                if ($received === 'test') {
-                    return true;
-                }
-                return false;
+                return $received === 'test';
             }
         ));
     }
@@ -93,10 +87,7 @@ class CustomRuleTest extends TestCase
         (new CustomRule(
             ['test'],
             function (string $received) {
-                if ($received === 'test') {
-                    return true;
-                }
-                return false;
+                return $received === 'test';
             }
         ));
     }
@@ -112,10 +103,7 @@ class CustomRuleTest extends TestCase
         (new CustomRule(
             ['test'],
             function (string $received): int {
-                if ($received === 'test') {
-                    return 1;
-                }
-                return 0;
+                return $received === 'test' ? 1: 0;
             }
         ));
     }
@@ -146,28 +134,16 @@ class CustomRuleTest extends TestCase
     {
         return [
             [function (string $received): bool {
-                if ($received === 'test') {
-                    return true;
-                }
-                return false;
+                return $received === 'test';
             }, 0, []],
             [function (string $received, $value): bool {
-                if ($received === $value) {
-                    return true;
-                }
-                return false;
+                return $received === $value;
             }, 1, ['string']],
             [function (string $received, int $min): bool {
-                if ($received >= $min) {
-                    return true;
-                }
-                return false;
+                return $received >= $min;
             }, 1, ['number']],
             [function (string $received, float $min, float $max): bool {
-                if ($received >= $min && $received <= $max) {
-                    return true;
-                }
-                return false;
+                return $received >= $min && $received <= $max;
             }, 2, ['number', 'number']]
         ];
     }
@@ -199,10 +175,7 @@ class CustomRuleTest extends TestCase
         $instance = new CustomRule(
             ['test'],
             function (string $received): bool {
-                if ($received === 'test') {
-                    return true;
-                }
-                return false;
+                return $received === 'test';
             }
         );
 

--- a/tests/Rules/IPv4RangeTest.php
+++ b/tests/Rules/IPv4RangeTest.php
@@ -102,7 +102,7 @@ class IPv4RangeTest extends TestCase
      */
     public function testValidCidrForAllValidSuffixes(int $suffix): void
     {
-        $this->assertSame(false, (new IPRange())->validate('192.168.0.48', "192.168.0.48/{$suffix}"));
+        $this->assertFalse((new IPRange())->validate('192.168.0.48', "192.168.0.48/{$suffix}"));
     }
 
     /**

--- a/tests/Rules/IPv6RangeTest.php
+++ b/tests/Rules/IPv6RangeTest.php
@@ -102,7 +102,7 @@ class IPv6RangeTest extends TestCase
      */
     public function testValidCidrForAllValidSuffixes(int $suffix): void
     {
-        $this->assertSame(false, (new IPRange())->validate('2001:abcd::0010', "2001:abcd::0010/{$suffix}"));
+        $this->assertFalse((new IPRange())->validate('2001:abcd::0010', "2001:abcd::0010/{$suffix}"));
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Remove `php-7.3-RC` because the `php-7.3` has been released by official PHP.
- Using the `assertFalse` to check whether the expected result is false.
- Using the `assertIsInt` to check whether expected value type is `int`.
- Using the short array syntax for test cases because of consistency.
- Replace `if-else` condition with `?:` and single `statement` to enhance the conditional statement.